### PR TITLE
docs: initial setup of the Center .github repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+This project is covered by the [Scala Code of Conduct](https://scala-lang.org/conduct/).
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Security Issue
+
+To report a security issue, please email
+[scala.center@epfl.ch](mailto:scala.center@epfl.ch) with a description of the
+issue, the steps you took to create the issue, affected versions, and, if known,
+mitigations for the issue. The Security Team will attempt to respond within a
+reasonable timeframe to your email. If the issue is confirmed as a
+vulnerability, we will open a Security Advisory.
+
+## Procedure
+
+1. A GitHub Security Advisory will be created in the appropriate repository.
+2. A project member works privately with the reporter to resolve the vulnerability.
+3. The project creates a new release of the package the vulnerability affects to deliver its fix.
+4. The project publicly announces the vulnerability and describes how to apply the fix.
+
+## Scala Steward
+
+We strongly recommend users of our libraries to use [Scala
+Steward](https://github.com/scala-steward-org/scala-steward) or something
+similar to automatically receive updates.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,19 @@
+Welcome to the Scala Center organization!
+
+Our primary focus is to:
+
+- Guide and support the Scala community
+- Coordinate and develop open source libraries and tools for the benefit of all
+    Scala users
+- Provide deep and quality educational materials for Scala
+
+You can read more about our purpose, see what we're working on, and find records
+of our doings on [scala.epfl.ch](https://scala.epfl.ch/).
+
+| Our communication channels                                                                                |
+| ----------------------------------------------------------------------------------------------------------|
+| [Twitter](https://twitter.com/scala): for general announcements about Scala                               |
+| [Discord](https://discord.gg/q8VJD4tCK4): to ask questions and discuss Scala-related topics               |
+| [LinkedIn](https://www.linkedin.com/company/scala-center/): Scala Center happenings                       |
+| [Contributors Forum](https://contributors.scala-lang.org/c/scala-center/25): project roadmaps and updates |
+| [Scala website](https://scala-lang.org/blog): general announcements about Scala                           |


### PR DESCRIPTION
This commit adds a few different things:

1. The `profile/README.md` which will be seen when a user lands on the organization page on GitHub which can be see in https://github.com/scalacenter. Currently there is nothing there. You can see some other examples like in [Scalameta](https://github.com/scalameta) and [Typelevel](https://github.com/typelevel). It's simple but provides a nice easy way for users to see our communication channels, our purpose, etc.
2. A default `CODE_OF_CONDUCT.md`. What this does is ensure that a default code of conduct can be referenced from any project under the Scala Center org even if the repo doesn't define one.
3. A default `SECURITY.md`. Same as the above, but about security related concerns.